### PR TITLE
Add semi: ["error", "always"] rule

### DIFF
--- a/packages/react-scripts/config/.eslintrc
+++ b/packages/react-scripts/config/.eslintrc
@@ -10,6 +10,7 @@
     "plugin:jsx-a11y/recommended"
   ],
   "rules": {
+    "semi": ["error", "always"],
     "quotes": ["error", "single"],
     "jsx-quotes": ["error", "prefer-single"],
     "import/no-extraneous-dependencies": ["error", {


### PR DESCRIPTION
Fixes the linter not adding the semicolons on the precommit hook.

It also now adds the semicolons on save 🙂