### PR TITLE
Version 1.1.4-cj release (.mdx and ci-lint)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ yarn add -D -E @credijusto/react-scripts
 
 This installs the devDependency, it supports all things Create React App offers AND:
 - Linting  with [AirBnb rules](https://github.com/airbnb/javascript)
-- Formatting with [Prettier](https://github.com/prettier/prettier) for `.html, .js, .jsx, .json, .css, .scss` extensions
+- Formatting with [Prettier](https://github.com/prettier/prettier) for `.html, .js, .jsx, .json, .css, .scss, .mdx` extensions
 - Precommit hook
 
 ### ESLint

--- a/packages/react-scripts/config/lintstagedrc.js
+++ b/packages/react-scripts/config/lintstagedrc.js
@@ -10,7 +10,7 @@ module.exports = {
       `eslint --fix --config ${eslintConfigPath} --ignore-path ${eslintIgnorePath}`,
       'git add'
     ],
-    './**/*.{html,json,css,scss}': [
+    './**/*.{html,json,css,scss,mdx}': [
       'prettier --write',
       'git add'
     ],

--- a/packages/react-scripts/package-lock.json
+++ b/packages/react-scripts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@credijusto/react-scripts",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@credijusto/react-scripts",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Custom Credijusto's configuration and scripts for Create React App.",
   "repository": "credijusto/create-react-app",
   "license": "MIT",

--- a/packages/react-scripts/scripts/lint.js
+++ b/packages/react-scripts/scripts/lint.js
@@ -1,24 +1,30 @@
 const paths = require('../config/paths');
 const { exec } = require('child_process');
 
-const prettierMatch = paths.appSrc + '/**/*.{html,js,jsx,json,css,scss,mdx}';
-const prettierCommand = `prettier '${prettierMatch}' --write`;
+const isCI = process.env.CI === 'true'
+
+const prettierMatch = paths.appSrc + '/**/*.{html,json,css,scss,mdx}';
+const prettierCommand = `prettier '${prettierMatch}' ${isCI ? '--check' : '--write'}`;
+
 const eslintConfigPath = paths.ownPath + '/config/.eslintrc';
 const eslintIgnorePath = paths.ownPath + '/config/.eslintignore';
-const eslintCommand = `eslint --fix --config ${eslintConfigPath} --ignore-path ${eslintIgnorePath} --ext .jsx,.js src/`;
+const eslintCommand = `eslint ${isCI ? '' : '--fix'} --config ${eslintConfigPath} --ignore-path ${eslintIgnorePath} --ext .jsx,.js src/`;
 
 exec(prettierCommand, (error, stdout, stderr) => {
   if (error) {
+    console.log(stdout);
+    console.log(stderr);
     console.log('Error: ' + error);
     process.exit(1);
   }
   console.log(stdout);
   console.log(stderr);
-  process.exit(0);
 });
 
 exec(eslintCommand, (error, stdout, stderr) => {
   if (error) {
+    console.log(stdout);
+    console.log(stderr);
     console.log('Error: ' + error);
     process.exit(1);
   }

--- a/packages/react-scripts/scripts/lint.js
+++ b/packages/react-scripts/scripts/lint.js
@@ -1,7 +1,7 @@
 const paths = require('../config/paths');
 const { exec } = require('child_process');
 
-const prettierMatch = paths.appSrc + '/**/*.{html,js,jsx,json,css,scss}';
+const prettierMatch = paths.appSrc + '/**/*.{html,js,jsx,json,css,scss,mdx}';
 const prettierCommand = `prettier '${prettierMatch}' --write`;
 const eslintConfigPath = paths.ownPath + '/config/.eslintrc';
 const eslintIgnorePath = paths.ownPath + '/config/.eslintignore';


### PR DESCRIPTION
v1.1.4-cj release:

- Add support to run `prettier` on `.mdx` files.
- Add the feature of running `lint` on `CI` mode. 
  - It will detect automatically a `CI` environment variable set to `true` on your pipeline. 
  - You have to add:
```
"ci-lint": "CI=true react-scripts lint"
```
 to your `package.json` scripts to run it locally.